### PR TITLE
Bumping timeout up for large collections of video/audio files

### DIFF
--- a/.github/workflows/run-addon.yml
+++ b/.github/workflows/run-addon.yml
@@ -6,6 +6,6 @@ jobs:
   Run-Add-On:
     uses: MuckRock/documentcloud-addon-workflows/.github/workflows/run-addon.yml@v1
     with:
-      timeout: 60
+      timeout: 180
       python-version: "3.9"
       apt-packages: ffmpeg


### PR DESCRIPTION
I don't think six hours will be necessary yet, but when running a folder for CRP, it was close to timeout (55 minutes), so I'm bumping to three horus