### PR TITLE
Fixes 403 error on some videos

### DIFF
--- a/main.py
+++ b/main.py
@@ -76,6 +76,7 @@ class Whisper(AddOn):
                 os.chdir("./out/")
                 ydl_opts = {'quiet': True, 'noplaylist': True}
                 with youtube_dl.YoutubeDL(ydl_opts) as ydl:
+                    ydl.cache.remove()
                     ydl.download([url])
                 os.chdir("..")
                 downloaded = True


### PR DESCRIPTION
As recommended here: https://stackoverflow.com/questions/61249612/error-unable-to-download-video-data-http-error-403-forbidden-while-using-yout